### PR TITLE
callback should return first argument as null if no error

### DIFF
--- a/lib/blitline.js
+++ b/lib/blitline.js
@@ -40,7 +40,7 @@ module.exports = function() {
         });
         res.resume();
         return res.on("end", function() {
-          return callback(JSON.parse(result.join()));
+          return callback(null, JSON.parse(result.join()));
         });
       });
 


### PR DESCRIPTION
In node.js it is standard practice for the first argument of a callback to be reserved for passing an error, and should null if there is no error.
This is a breaking change that will cause existing code to not work, but it follows conventions used by most other node libraries.
