### PR TITLE
Chunked responses should be joined with empty string

### DIFF
--- a/lib/blitline.js
+++ b/lib/blitline.js
@@ -40,7 +40,7 @@ module.exports = function() {
         });
         res.resume();
         return res.on("end", function() {
-          return callback(JSON.parse(result.join()));
+          return callback(JSON.parse(result.join('')));
         });
       });
 


### PR DESCRIPTION
`Array.prototype.join()` without any arguments defaults to joining strings with a comma. This can lead to incorrect JSON when joining the chunked response. Should use an empty string to join the results from the http request.
