### PR TITLE
Parse job result errors

### DIFF
--- a/lib/blitline.js
+++ b/lib/blitline.js
@@ -40,7 +40,12 @@ module.exports = function() {
         });
         res.resume();
         return res.on("end", function() {
-          var data = JSON.parse(result.join(''));
+          var data;
+          try {
+            data = JSON.parse(result.join(''));
+          } catch (e) {
+            return callback(e);
+          }
           var error;
           data.results.forEach(function(result) {
             // Will only return the error for the last job for multiple jobs.


### PR DESCRIPTION
Parse job results for any errors and return an error, otherwise return parsed JSON.

This will only work with API >= v1.20. In earlier versions it simply will not catch the errors and pass back the JSON response.

This incorporates #5 and #6.
