### PR TITLE
Use https for API requests.

### DIFF
--- a/lib/blitline.js
+++ b/lib/blitline.js
@@ -4,7 +4,7 @@
 
 exports.version = '2.0.1';
 
-var http = require('http');
+var https = require('https');
 var url = require('url');
 /**
  * Exports.
@@ -23,16 +23,18 @@ module.exports = function() {
     var body = JSON.stringify({ "json" : jobs });
     options = {
           "host": "api.blitline.com",
-          "port": 80,
+          "port": 443,
           "path": "/job",
           "method": "post",
           "headers": {
             'Content-Length': body.length,
             'Content-Type': 'application/json'
-          }
+          },
+          "rejectUnauthorized": true
         };
+    options.agent = new https.Agent(options);
     jobs = [];
-    req = http.request(options, function(res) {
+    req = https.request(options, function(res) {
         var result;
         result = [];
         res.on("data", function(chunk) {


### PR DESCRIPTION
API requests should not be sent unencrypted.
