### PR TITLE
Correctly set Content-length in https.request options

### DIFF
--- a/lib/blitline.js
+++ b/lib/blitline.js
@@ -42,7 +42,7 @@ module.exports = function() {
         path: '/job',
         method: 'POST',
         headers: {
-          'Content-Length': body.length,
+          'Content-Length': Buffer.byteLength(body),
           'Content-Type': 'application/json'
         },
         rejectUnauthorized: true


### PR DESCRIPTION
As stated in https://nodejs.org/api/http.html:
Currently: body.length

Should be:
 Buffer.byteLength(body)